### PR TITLE
Potential fix for code scanning alert no. 1: Insecure randomness

### DIFF
--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -10,6 +10,7 @@ import type { DBMessage, Document } from '@/lib/db/schema';
 import { ChatSDKError, type ErrorCode } from './errors';
 import type { ChatMessage, ChatTools, CustomUIDataTypes } from './types';
 import { formatISO } from 'date-fns';
+import { randomUUID, randomBytes } from 'crypto';
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
@@ -56,11 +57,23 @@ export function getLocalStorage(key: string) {
 }
 
 export function generateUUID(): string {
-  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
-    const r = (Math.random() * 16) | 0;
-    const v = c === 'x' ? r : (r & 0x3) | 0x8;
-    return v.toString(16);
-  });
+  // Use crypto.randomUUID if available (Node.js v14.17+)
+  if (typeof randomUUID === 'function') {
+    return randomUUID();
+  }
+  // Fallback for older Node.js: generate UUID v4 from randomBytes
+  const bytes = randomBytes(16);
+  // Per RFC 4122 section 4.4
+  bytes[6] = (bytes[6] & 0x0f) | 0x40; // version 4
+  bytes[8] = (bytes[8] & 0x3f) | 0x80; // variant 10
+  const hex = Array.from(bytes).map(b => b.toString(16).padStart(2, '0')).join('');
+  return (
+    hex.slice(0, 8) + '-' +
+    hex.slice(8, 12) + '-' +
+    hex.slice(12, 16) + '-' +
+    hex.slice(16, 20) + '-' +
+    hex.slice(20)
+  );
 }
 
 type ResponseMessageWithoutId = CoreToolMessage | CoreAssistantMessage;


### PR DESCRIPTION
Potential fix for [https://github.com/IzaacCoding36/NeoGen/security/code-scanning/1](https://github.com/IzaacCoding36/NeoGen/security/code-scanning/1)

To fix the problem, we need to ensure that UUIDs (or any random values used as passwords) are generated using a cryptographically secure random number generator. In Node.js, this can be achieved using the `crypto` module's `randomUUID()` or `randomBytes()` functions. The best fix is to replace the implementation of `generateUUID` in `lib/utils.ts` to use `crypto.randomUUID()` if available (Node.js v14.17+), or a secure fallback using `crypto.randomBytes` for older versions. This change will ensure that all UUIDs generated are cryptographically secure, and thus any passwords derived from them will be unpredictable.

**Required changes:**
- In `lib/utils.ts`, import the Node.js `crypto` module.
- Replace the body of `generateUUID` to use `crypto.randomUUID()` (or a secure fallback).
- No changes are needed in `lib/db/queries.ts` or `lib/db/utils.ts` since they call `generateUUID` and will automatically benefit from the improved implementation.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
